### PR TITLE
Fix build/plan agent prompt injection

### DIFF
--- a/src/orchestration/prompt.ts
+++ b/src/orchestration/prompt.ts
@@ -289,3 +289,14 @@ The system automatically reminds you if you go idle with incomplete tasks.
 - The session goes idle
 - There's been sufficient time since the last reminder
 `
+
+export function getOrchestrationPrompt(agent: "build" | "plan" | string | undefined): string | undefined {
+  switch (agent) {
+    case "build":
+      return ORCHESTRATION_PROMPT
+    case "plan":
+      return ORCHESTRATION_PROMPT
+    default:
+      return undefined
+  }
+}

--- a/src/orchestration/session-agent-tracker.ts
+++ b/src/orchestration/session-agent-tracker.ts
@@ -1,0 +1,62 @@
+/**
+ * Session-Agent Tracker
+ * 
+ * Tracks which agent is active for each session, allowing the system transform
+ * hook to inject agent-specific prompts.
+ * 
+ * Flow:
+ * 1. chat.message hook fires with { sessionID, agent }
+ * 2. We store the mapping: sessionID -> agentName
+ * 3. experimental.chat.system.transform fires with { sessionID }
+ * 4. We look up the agent and inject the appropriate prompt
+ */
+
+/** Map of sessionID to agent name */
+const sessionAgentMap = new Map<string, string>()
+
+/**
+ * Record which agent is active for a session.
+ * Called from chat.message hook.
+ */
+export function setSessionAgent(sessionID: string, agent: string | undefined): void {
+  if (agent) {
+    sessionAgentMap.set(sessionID, agent)
+  }
+}
+
+/**
+ * Get the active agent for a session.
+ * Called from experimental.chat.system.transform hook.
+ */
+export function getSessionAgent(sessionID: string): string | undefined {
+  return sessionAgentMap.get(sessionID)
+}
+
+/**
+ * Clear tracking for a session (on deletion).
+ */
+export function clearSessionAgent(sessionID: string | undefined): void {
+  if (sessionID) {
+    sessionAgentMap.delete(sessionID)
+  }
+}
+
+/**
+ * Check if an agent should receive orchestration injection.
+ * Only build and plan agents get the orchestration prompt.
+ */
+export function shouldInjectOrchestration(agent: string | undefined): boolean {
+  if (!agent) return false
+  return agent === "build" || agent === "plan"
+}
+
+/**
+ * Get the agent type for prompt selection.
+ * Returns "build", "plan", or string for other agents.
+ */
+export function getOrchestrationAgentType(agent: string | undefined): "build" | "plan" | string | undefined {
+  if (agent === "build") return "build"
+  if (agent === "plan") return "plan"
+  if (agent === undefined) return undefined
+  return agent
+}


### PR DESCRIPTION
Fixes #1 

**Problem**: The orchestration prompts were never being injected into the build and plan agents.

The previous approach tried to inject via the config hook:
```typescript
if (config.agent.build) {
  config.agent.build.prompt = existingPrompt + ORCHESTRATION_PROMPT
}
```

This silently fails because OpenCode's built-in agents (build, plan, etc.) don't exist in config.agent by default. They're defined internally. The config object only contains agents that users explicitly override in their `opencode.json`, which most don't do -- well it seems that way from the discord.

**Solution**: Use experimental.chat.system.transform hook instead, which fires during LLM calls and appends to the already constructed system prompt array.

Note, the experimental.chat.system.transform hook only receives { sessionID } in its input. So no agent information is passed (though it's available at the call site in opencode's llm.ts, this could be something to raise back to the maintainers).

**Workaround**: We track the active agent per session ourselves:

1. chat.message hook fires first with { sessionID, agent } → we store the mapping
2. experimental.chat.system.transform fires next → we look up the agent from sessionID
3. Inject agent-specific prompt only for build or plan agents

This also enables a bonus improvement, which I haven't implemented but you could now look at: agent-specific injected prompts. Build agent gets execution-focused guidance ("delegate research, execute code") while Plan agent gets planning-focused guidance ("research thoroughly before planning").

*Test*

As mentioned in the issue, you can add something obvious to the prompt to test this:

<img width="141" height="74" alt="Screenshot 2026-01-17 at 22 36 26" src="https://github.com/user-attachments/assets/78572b5e-e9a1-476b-838f-8a47d127122f" />
