### PR TITLE
feat(config): add auto_update.show_startup_toast config option

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,12 +36,19 @@ export const AgentOverridesSchema = z.object({
 
 export type AgentOverrides = z.infer<typeof AgentOverridesSchema>
 
+export const AutoUpdateConfigSchema = z.object({
+  show_startup_toast: z.boolean().optional(),
+})
+
+export type AutoUpdateConfig = z.infer<typeof AutoUpdateConfigSchema>
+
 /**
  * Main configuration schema for zenox
  */
 export const ZenoxConfigSchema = z.object({
   $schema: z.string().optional(),
   agents: AgentOverridesSchema.optional(),
+  auto_update: AutoUpdateConfigSchema.optional(),
   disabled_agents: z.array(AgentNameSchema).optional(),
   disabled_mcps: z.array(McpNameSchema).optional(),
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,9 @@ const ZenoxPlugin: Plugin = async (ctx) => {
   const backgroundTools = createBackgroundTools(backgroundManager, ctx.client)
 
   // Initialize hooks
-  const autoUpdateHook = createAutoUpdateHook(ctx)
+  const autoUpdateHook = createAutoUpdateHook(ctx, {
+    showStartupToast: pluginConfig.auto_update?.show_startup_toast,
+  })
   const keywordDetectorHook = createKeywordDetectorHook(ctx)
   const todoEnforcerHook = createTodoEnforcerHook(ctx)
 


### PR DESCRIPTION
## Summary
- add `auto_update.show_startup_toast` to the Zenox config schema
- wire the config into `createAutoUpdateHook` so startup toast display can be toggled by users

## Why
Users may want to disable startup update toasts while still keeping auto-update behavior enabled.

## Validation
- bun run typecheck